### PR TITLE
Fix I2C handing:

### DIFF
--- a/ch341-i2c.c
+++ b/ch341-i2c.c
@@ -29,206 +29,186 @@
 #define CH341_CTRL_VENDOR_VERSION 0x5F	 /* version of chip */
 #define CH341_CTRL_VENDOR_READ_TYPE 0XC0 /* vendor control read */
 
-/* Append a write command to the current request. A set of 32-byte
- * packets is filled. Each packet starts with STREAM and finishes with
- * END, and contains an OUT field, leaving up to 29 bytes of data. The
- * first packet must also include a START and the device address.
- */
-static int append_write(struct ch341_device *dev, const struct i2c_msg *msg)
+
+static int ch341_i2c_quick_write(struct ch341_device *dev, struct i2c_msg *msg)
 {
-	u8 *out = dev->i2c_buf;
-	int len;
-	u8 *p;
-	bool start_done = false;
+    int retval, actual = 0;
+    uint8_t *ptr = 0;
 
-	len = msg->len;
-	p = msg->buf;
+    mutex_lock(&dev->usb_lock);
+    ptr = dev->i2c_outbuf;
+    *ptr++ = CH341_CMD_I2C_STREAM;
+    *ptr++ = CH341_CMD_I2C_STM_STA;
+    *ptr++ = CH341_CMD_I2C_STM_OUT; // wlen=0 is same as wlen=1 but also ask for status from I2C
+    *ptr++ = msg->addr << 1;
+    *ptr++ = CH341_CMD_I2C_STM_STO;
 
-	while (len) {
-		int to_write;
-		int avail;
-
-		if (dev->idx_out % SEG_SIZE) {
-			/* Finish current packet, and advance to the next one */
-			out[dev->idx_out++] = CH341_CMD_I2C_STM_END;
-			dev->out_seg++;
-			dev->idx_out = dev->out_seg * SEG_SIZE;
-
-			if (dev->out_seg == SEG_COUNT)
-				return -E2BIG;
-		}
-
-		out[dev->idx_out++] = CH341_CMD_I2C_STREAM;
-
-		/* account for stream start and end */
-		avail = SEG_SIZE - 3;
-
-		if (!start_done) {
-			/* Each message has a start */
-			out[dev->idx_out++] = CH341_CMD_I2C_STM_STA;
-
-			avail -= 2; /* room for STA and device address */
-		}
-
-		to_write = min_t(int, len, avail);
-
-		if (!start_done) {
-			out[dev->idx_out++] = CH341_CMD_I2C_STM_OUT | (to_write + 1);
-			out[dev->idx_out++] = msg->addr << 1;
-
-			start_done = true;
-		} else {
-			out[dev->idx_out++] = CH341_CMD_I2C_STM_OUT | to_write;
-		}
-
-		memcpy(&out[dev->idx_out], p, to_write);
-		dev->idx_out += to_write;
-		len -= to_write;
-		p += to_write;
-	}
-
-	return 0;
+    retval = usb_bulk_msg(dev->usb_dev, usb_sndbulkpipe(dev->usb_dev, dev->ep_out), dev->i2c_outbuf, ptr - dev->i2c_outbuf, &actual, 2000);
+    if (retval < 0)
+        goto unlock;
+    retval = usb_bulk_msg(dev->usb_dev, usb_rcvbulkpipe(dev->usb_dev, dev->ep_in), dev->i2c_inbuf, 8, &actual, 2000);
+    if (retval < 0)
+        goto unlock;
+    if (dev->i2c_inbuf[0] & 0x80) // check status for NACK
+        retval = -ETIMEDOUT;
+unlock:
+    mutex_unlock(&dev->usb_lock);
+    return retval;
 }
 
-/* Append a read command to the request. It usually follows a write
- * command. When that happens, the driver will attempt to concat the
- * read command into the same packet.  Each read command, of up to 32
- * bytes, must be written to a new packet. It is not possible to
- * concat them.
- */
-static int append_read(struct ch341_device *dev, const struct i2c_msg *msg)
+int ch341_i2c_read(struct ch341_device *dev, struct i2c_msg *msg)
 {
-	u8 *out = dev->i2c_buf;
-	bool start_done = false;
-	int len;
+    int byteoffset = 0, bytestoread;
+    int ret = 0, actual = 0;
+    uint8_t *ptr;
+    while (msg->len - byteoffset > 0) {
+        mutex_lock(&dev->usb_lock);
 
-	len = msg->len;
+        bytestoread = msg->len - byteoffset;
+        if (bytestoread > 31)
+            bytestoread = 31;
+        ptr = dev->i2c_outbuf;
+        *ptr++ = CH341_CMD_I2C_STREAM;
+        *ptr++ = CH341_CMD_I2C_STM_STA;
+        *ptr++ = CH341_CMD_I2C_STM_OUT; // wlen=0 is same as wlen=1 but also ask for status from I2C
+        *ptr++ = (msg->addr << 1) | 1;
+        if (bytestoread > 1) {
+            *ptr++ = CH341_CMD_I2C_STM_IN | (bytestoread - 1);
+        }
+        *ptr++ = CH341_CMD_I2C_STM_IN;
+        *ptr++ = CH341_CMD_I2C_STM_STO;
 
-	while (len) {
-		int to_read;
+        ret = usb_bulk_msg(dev->usb_dev, usb_sndbulkpipe(dev->usb_dev, dev->ep_out), dev->i2c_outbuf, ptr - dev->i2c_outbuf, &actual, 2000);
+        if (ret < 0)
+            goto unlock;
+        ret = usb_bulk_msg(dev->usb_dev, usb_rcvbulkpipe(dev->usb_dev, dev->ep_in), dev->i2c_inbuf, 32, &actual, 2000);
+        if (ret < 0)
+            goto unlock;
+        if (dev->i2c_inbuf[0] & 0x80) // check status for NACK
+            ret = -ETIMEDOUT;
+        if (ret > -1) {
+            memcpy(&msg->buf[byteoffset], &dev->i2c_inbuf[1], bytestoread);
+            byteoffset += bytestoread;
+        }
+unlock:
+        mutex_unlock(&dev->usb_lock);
 
-		if (dev->idx_out % SEG_SIZE) {
-			if (!start_done &&
-			    (dev->idx_out % SEG_SIZE) <  (SEG_SIZE - 7)) {
-				/* There's enough left for a read */
-			} else {
-				/* Finish current packet, and advance to the next one */
-				out[dev->idx_out++] = CH341_CMD_I2C_STM_END;
-				dev->out_seg++;
-				dev->idx_out = dev->out_seg * SEG_SIZE;
-
-				if (dev->out_seg == SEG_COUNT)
-					return -E2BIG;
-
-				out[dev->idx_out++] = CH341_CMD_I2C_STREAM;
-			}
-		} else {
-			out[dev->idx_out++] = CH341_CMD_I2C_STREAM;
-		}
-
-		if (!start_done) {
-			/* Each message has a start */
-			out[dev->idx_out++] = CH341_CMD_I2C_STM_STA;
-			out[dev->idx_out++] = CH341_CMD_I2C_STM_OUT | 1;
-			out[dev->idx_out++] = msg->addr << 1 | 1;
-
-			start_done = true;
-		}
-
-		/* Apparently the last command must be an STM_IN to
-		 * read the last byte. Without it, the adapter gets
-		 * lost.
-		 */
-		to_read = min_t(int, len, 32);
-		len -= to_read;
-		if (len == 0) {
-			if (to_read > 1)
-				out[dev->idx_out++] = CH341_CMD_I2C_STM_IN | (to_read - 1);
-			out[dev->idx_out++] = CH341_CMD_I2C_STM_IN;
-		} else {
-			out[dev->idx_out++] = CH341_CMD_I2C_STM_IN | to_read;
-		}
-	}
-
-	return 0;
+        if (ret < 0)
+            break;
+    }
+    return ret;
 }
 
-static int ch341_i2c_xfer(struct i2c_adapter *adapter, struct i2c_msg *msgs, int num)
+static int ch341_usb_transfer(struct ch341_device *ch341_dev, int out_len,int in_len)
 {
-	struct ch341_device *dev = adapter->algo_data;
-	int retval;
-	int i;
-	u8 *out = dev->i2c_buf;
-	int actual;
+    int retval;
+    int actual;
 
-	/* Prepare the request */
-	dev->idx_out = 0;
-	dev->out_seg = 0;
+    //DEV_INFO (CH341_IF_ADDR, "bulk_out %d bytes, bulk_in %d bytes", out_len, (in_len == 0) ? 0 : CH341_USB_MAX_BULK_SIZE);
 
-	for (i = 0; i != num; i++) {
-		if (msgs[i].flags & I2C_M_RD)
-			retval = append_read(dev, &msgs[i]);
-		else
-			retval = append_write(dev, &msgs[i]);
+    retval = usb_bulk_msg(ch341_dev->usb_dev, usb_sndbulkpipe(ch341_dev->usb_dev, ch341_dev->ep_out),
+                            ch341_dev->i2c_outbuf, out_len, &actual, 2000);
+    if (retval < 0)
+        return retval;
 
-		if (retval)
-			return retval;
-	}
+    if (in_len == 0)
+        return actual;
 
-	/* Finish the last packet */
-	if (SEG_SIZE - (dev->idx_out % SEG_SIZE) < 2) {
-		out[dev->idx_out++] = CH341_CMD_I2C_STM_END;
+    memset(ch341_dev->i2c_inbuf, 0, sizeof(ch341_dev->i2c_inbuf));
+    retval = usb_bulk_msg(ch341_dev->usb_dev, usb_rcvbulkpipe(ch341_dev->usb_dev, ch341_dev->ep_in),
+                            ch341_dev->i2c_inbuf, SEG_SIZE, &actual, 2000);
 
-		dev->out_seg++;
-		if (dev->out_seg == SEG_COUNT)
-			return -E2BIG;
+    if (retval < 0)
+        return retval;
 
-		dev->idx_out = dev->out_seg * SEG_SIZE;
+    return actual;
+}
 
-		out[dev->idx_out++] = CH341_CMD_I2C_STREAM;
-	}
+int ch341_i2c_write(struct ch341_device *dev, struct i2c_msg *msg) {
+    unsigned left = msg->len, avail, wlen;
+    uint8_t *ptr = msg->buf, *outptr, *lenptr;
+    int ret = 0;
+    bool first = true;
+    do {
+        mutex_lock(&dev->usb_lock);
 
-	out[dev->idx_out++] = CH341_CMD_I2C_STM_STO;
-	out[dev->idx_out++] = CH341_CMD_I2C_STM_END;
+        outptr = dev->i2c_outbuf;
+        *outptr++ = CH341_CMD_I2C_STREAM;
+        if (first) { // Start packet
+            *outptr++ = CH341_CMD_I2C_STM_STA;
+        }
+        lenptr = outptr++;
+        if (first) {
+            *outptr++ = msg->addr << 1;
+        }
+        avail = 32 - (outptr - dev->i2c_outbuf);
+        wlen = avail;
+        if (left < avail) {
+            wlen = left;
+        } else if (left == avail) {
+            wlen = avail - 1;
+        }
+        memcpy(outptr, ptr, wlen);
+        outptr += wlen;
+        ptr += wlen;
+        left -= wlen;
+        wlen = outptr - lenptr - 1;
+        *lenptr = CH341_CMD_I2C_STM_OUT | wlen;
+        if (left == 0) {  // Stop packet
+            *outptr++ = CH341_CMD_I2C_STM_STO;
+        }
+        first = false;
+        ret = ch341_usb_transfer(dev, outptr - dev->i2c_outbuf, 0);
 
-	dev_dbg(&dev->adapter.dev, "bulk_out request with %d bytes\n",
-		dev->idx_out);
+        mutex_unlock(&dev->usb_lock);
 
-	mutex_lock(&dev->usb_lock);
+        if (ret < 0)
+            break;
+    } while (left);
 
-	/* Issue the request */
-	retval = usb_bulk_msg(dev->usb_dev,
-			      usb_sndbulkpipe(dev->usb_dev, dev->ep_out),
-			      dev->i2c_buf, dev->idx_out, &actual, DEFAULT_TIMEOUT);
-	if (retval < 0) {
-		mutex_unlock(&dev->usb_lock);
-		return retval;
-	}
+    return ret;
+}
 
-	for (i = 0; i != num; i++) {
-		if (!(msgs[i].flags & I2C_M_RD))
-			continue;
+#define CHECK_PARAM_RET(cond,err) if (!(cond)) return err;
 
-		retval = usb_bulk_msg(dev->usb_dev,
-				      usb_rcvbulkpipe(dev->usb_dev, dev->ep_in),
-				      dev->i2c_buf, msgs[i].len, &actual, DEFAULT_TIMEOUT);
+static int ch341_i2c_xfer(struct i2c_adapter *adpt, struct i2c_msg *msgs, int num)
+{
+    struct ch341_device *dev;
+    int result;
+    int i;
 
-		if (retval) {
-			mutex_unlock(&dev->usb_lock);
-			return retval;
-		}
+    CHECK_PARAM_RET(adpt, EIO);
+    CHECK_PARAM_RET(msgs, EIO);
+    CHECK_PARAM_RET(num > 0, EIO);
 
-		if (actual != msgs[i].len) {
-			mutex_unlock(&dev->usb_lock);
-			return -EIO;
-		}
+    dev = (struct ch341_device *)adpt->algo_data;
 
-		memcpy(msgs[i].buf, dev->i2c_buf, actual);
-	}
+    CHECK_PARAM_RET(dev, EIO);
 
-	mutex_unlock(&dev->usb_lock);
+    for (i = 0; i < num; ++i) {
+        if (msgs[i].flags & I2C_M_TEN) {
+            dev_err(&dev->iface->dev, "10 bit i2c addresses are not supported");
+            result = -EINVAL;
+            break;
+        }
+        if (msgs[i].flags & I2C_M_RD) {
+            result = ch341_i2c_read(dev, &msgs[i]); // checks for NACK of msg->addr
+            if (result < 0)
+                break;
+        } else {
+            result = ch341_i2c_quick_write(dev, &msgs[i]); // checks for NACK of msg->addr
+            if (result < 0)
+                break;
+            result = ch341_i2c_write(dev, &msgs[i]);
+            if (result < 0)
+                break;
+        }
+    }
 
-	return num;
+    if (result < 0)
+        return result;
+
+    return num;
 }
 
 static u32 ch341_i2c_func(struct i2c_adapter *adap)
@@ -265,13 +245,12 @@ int ch341_i2c_init(struct ch341_device *dev)
 	dev->adapter.dev.parent = &dev->iface->dev;
 
 	/* Set ch341 i2c speed */
-	dev->i2c_buf[0] = CH341_CMD_I2C_STREAM;
-	dev->i2c_buf[1] = CH341_CMD_I2C_STM_SET | CH341_I2C_STANDARD_SPEED;
-	dev->i2c_buf[2] = CH341_CMD_I2C_STM_END;
+    dev->i2c_outbuf[0] = CH341_CMD_I2C_STREAM;
+    dev->i2c_outbuf[1] = CH341_CMD_I2C_STM_SET | CH341_I2C_STANDARD_SPEED;
 	mutex_lock(&dev->usb_lock);
 	retval = usb_bulk_msg(dev->usb_dev,
 			      usb_sndbulkpipe(dev->usb_dev, dev->ep_out),
-			      dev->i2c_buf, 3, &actual, DEFAULT_TIMEOUT);
+                  dev->i2c_outbuf, 2, &actual, DEFAULT_TIMEOUT);
 	mutex_unlock(&dev->usb_lock);
 	if (retval < 0) {
 		dev_err(&dev->iface->dev, "Cannot set I2C speed\n");

--- a/ch341.h
+++ b/ch341.h
@@ -16,7 +16,6 @@
  * split, with up to 32-byte per segment.
  */
 #define SEG_SIZE 32
-#define SEG_COUNT 128
 
 /* Number of SPI devices the device can control */
 #define CH341_SPI_MAX_NUM_DEVICES 4
@@ -43,9 +42,8 @@ struct ch341_device {
 	bool i2c_init;
 
 	/* I2C request and response state */
-	int idx_out;		/* current offset in buf */
-	int out_seg;		/* current segment */
-	u8 i2c_buf[SEG_COUNT * SEG_SIZE];
+    u8 i2c_inbuf[SEG_SIZE];
+    u8 i2c_outbuf[SEG_SIZE];
 
 	/* GPIO */
 	struct gpio_chip gpio;


### PR DESCRIPTION
        1. no limit on size
        2. write of EEPROM works
        3. i2cdetect works properly in both -q (WRITE0) and -r (READ1) modes