### PR TITLE
README.rst: mention i2c-dev dependency for i2cdetect.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,15 @@ The ch341 supports 4 different speeds: 20kHz, 100kHz, 400kHz and
 cannot be dynamically changed. It is possible to change it in the
 ch341_i2c_init() function. A future patch should address that issue.
 
+I2cdetect requires the i2c-dev module to be loaded. You can load it once::
+
+  $ modprobe i2c-dev
+
+Or add it to /etc/modules-load.d/ to autoload the module at boot time::
+
+  $ echo 'i2c-dev' > /etc/modules-load.d/i2c-dev.conf
+  $ systemctl restart systemd-modules-load.service
+
 To find the device number::
 
   $ i2cdetect -l


### PR DESCRIPTION
Hi,
as I had some trouble to recognize that i2cdetect needs i2c-dev I created this PR to help others. On some distributions, the package for the i2cdetect tool adds a config file to autoload the module. On others, it doesn't. 
I'm not sure if this should be written more generally in a way to first check if the module is already loaded or not. But I didn't want to clutter the documentation too much.  But I can add that step if you prefer.