### PR TITLE
spi-ch341.c: change SPI_MASTER_MUST_ to SPI_CONTROLLER_MUST_

### DIFF
--- a/spi-ch341.c
+++ b/spi-ch341.c
@@ -517,7 +517,7 @@ static int ch341_spi_probe(struct platform_device *pdev)
 	master->bus_num = -1;
 	master->num_chipselect = CH341_SPI_MAX_NUM_DEVICES;
 	master->mode_bits = SPI_MODE_0 | SPI_LSB_FIRST;
-	master->flags = SPI_MASTER_MUST_RX | SPI_MASTER_MUST_TX;
+	master->flags = SPI_CONTROLLER_MUST_RX | SPI_CONTROLLER_MUST_TX;
 	master->bits_per_word_mask = SPI_BPW_MASK(8);
 	master->transfer_one_message = ch341_spi_transfer_one_message;
 	master->max_speed_hz = CH341_SPI_MAX_FREQ;


### PR DESCRIPTION
Newer kernels, in my case 6.6.1 changed the SPI_MASTER_MUST_ to SPI_CONTROLLER_MUST_