### PR TITLE
Put back IRQCHIP_IMMUTABLE definition for 5.19 kernels

### DIFF
--- a/gpio-ch341.c
+++ b/gpio-ch341.c
@@ -94,6 +94,8 @@ static inline void gpio_irq_chip_set_chip(struct gpio_irq_chip *girq,
 	girq->chip = (struct irq_chip *)chip;
 }
 
+/* Flag not supported before 5.19 */
+#define IRQCHIP_IMMUTABLE 0
 
 #else
 #define IMMUTABLE_DECL const


### PR DESCRIPTION
It was inadvertantly removed in previous commit.